### PR TITLE
Fixed compiler hints and warnings.

### DIFF
--- a/Source/AutoMapper.ConfigurationProvider.pas
+++ b/Source/AutoMapper.ConfigurationProvider.pas
@@ -10,17 +10,16 @@ type
   protected
     FCfgMapper: TCfgMapper;
     constructor Create(const CfgMapper: TCfgMapper); virtual;
-    destructor Destroy; override;
   public
     function CreateMap<TSource: Class; TDestination: Class>(const MappingExpression: TMapExpression<TSource, TDestination>): TConfigurationProvider; overload;
     function CreateMap<TSource: Class; TDestination: Class>(): TConfigurationProvider; overload;
-
     procedure Validate;
+    destructor Destroy; override;
   end;
 
   TConfigurationProvderRunTime = class(TConfigurationProvider)
   public
-    constructor Create(const CfgMapper: TCfgMapper); overload;
+    constructor Create(const CfgMapper: TCfgMapper); reintroduce;
   end;
 
 implementation

--- a/Source/AutoMapper.Mapper.pas
+++ b/Source/AutoMapper.Mapper.pas
@@ -15,7 +15,7 @@ type
   TMapper = class
   strict private
     class var FInstance: TMapper;
-    destructor Destroy; override;
+    class destructor Destroy;
   private
     ActionCfg: TActionConfigurationProvider;
     Configuration: TConfigurationProvider;
@@ -110,10 +110,11 @@ begin
   Result := FInstance;
 end;
 
-destructor TMapper.Destroy;
+class destructor TMapper.Destroy;
 begin
   Reset;
-  Inherited;
+  if Assigned(TMapper.FInstance) then
+    TMapper.FInstance.Free;
 end;
 
 initialization

--- a/Source/AutoMapper.MappingExpression.pas
+++ b/Source/AutoMapper.MappingExpression.pas
@@ -133,6 +133,7 @@ begin
   Ctx := TRttiContext.Create;
   FSourceRttiType := Ctx.GetType(source.ClassType);
   FDestRttiType   := Ctx.GetType(dest.ClassType);
+  FDestRttiField := default(TRttiField);
 
   for FDestRttiField in FDestRttiType.GetFields do
     for FSourceRttiField in FSourceRttiType.GetFields do


### PR DESCRIPTION
Hi Sergei, thx for this cool library. I did some changes on my fork, cause warnings / hints burn my eyes :)
Some thoughts:
1. There is no point to hide TConfigurationProvder.Destroy, it is mostly never called directly.
2. TConfigurationProvderRunTime is redundant, please consider it's removal.
3. Did not look deeply into FDestRttiField, please think of throwing exception as an alternative ty my default  initialization.
